### PR TITLE
Add DisableInitialHostLookup to CassandraConfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ _testmain.go
 *.exe
 *.test
 *.prof
+.idea/

--- a/cassandra.go
+++ b/cassandra.go
@@ -40,6 +40,7 @@ type CassandraConfig struct {
 	NumConns         int      `config:"optional"` // number of connections per host (default: 2)
 	Port             int      `config:"optional"` // port to connect to, default: 9042
 	NumRetries       int      `config:"optional" yaml:"num_retries"` // number of retries in case of connection timeout
+	DisableInitialHostLookup bool // Don't preform ip address discovery on the cluster, just use the Nodes provided
 
 	// TestMode affects whether a keyspace creation will be attempted on Cassandra initialization.
 	TestMode bool `config:"optional"`
@@ -215,6 +216,7 @@ func setDefaults(cfg CassandraConfig) (*gocql.ClusterConfig, error) {
 	cluster.SocketKeepalive = keepAlive
 	cluster.Port = cfg.Port
 	cluster.HostFilter = gocql.DataCentreHostFilter(cfg.DataCenter)
+	cluster.DisableInitialHostLookup = cfg.DisableInitialHostLookup
 
 	if cfg.NumRetries != 0 {
 		cluster.RetryPolicy = &gocql.SimpleRetryPolicy{NumRetries: cfg.NumRetries}


### PR DESCRIPTION
# Purpose
When *gocql* connects to a cluster it queries the `broadcast_address` from `system.local` then disconnects and establishes a new connection pool to the addresses listed. On systems where the broadcast table is not setup or is inaccurate (such as when Cassandra is running inside a container) *gocql* does not fallback to the addresses provided in the config, it instead returns the error `no connections were made when creating the session`.  Providing the `DisableInitialHostLookup` disables queries of the `broadcast_address` from `system.local` and forces *gocql* to connect only to the hosts provided.

# Implementation
Added `DisableInitialHostLookup` to `CassandraConfig`