### PR TITLE
Update to support latest gocql

### DIFF
--- a/cassandra.go
+++ b/cassandra.go
@@ -187,7 +187,7 @@ func (c *cassandra) IterQuery(queryString string, queryParams []interface{}, out
 
 // Return appropriate gocql.Consistency based on the provided consistency level name.
 func translateConsistency(consistencyName string) (gocql.Consistency, error) {
-	return gocql.ParseConsistency(consistencyName), nil
+	return gocql.ParseConsistency(consistencyName)
 }
 
 func translateDuration(k string, df time.Duration) (time.Duration, error) {


### PR DESCRIPTION
## Purpose
gocql seemed to start adding err messages in the return signature of this code.
Updated our wrapper to pass the err down rather than always returning nil.
## Impl
Removed old return blah, nil and just return what the consistency call returns