### PR TITLE
Added Session() to retrieve the `gocql.Session` object

### DIFF
--- a/cassandra.go
+++ b/cassandra.go
@@ -18,6 +18,7 @@ type Cassandra interface {
 	IterQuery(string, []interface{}, ...interface{}) func() (int, bool, error)
 	Close() error
 	Config() CassandraConfig
+	Session() *gocql.Session
 }
 
 type cassandra struct {
@@ -104,6 +105,10 @@ func (c *cassandra) Close() error {
 
 func (c *cassandra) Config() CassandraConfig {
 	return c.config
+}
+
+func (c *cassandra) Session() *gocql.Session {
+	return c.session
 }
 
 // Query provides an access to the gocql.Query if a user of this library needs to tune some parameters for

--- a/testutils.go
+++ b/testutils.go
@@ -20,6 +20,10 @@ func (c *TestErrorCassandra) Config() CassandraConfig {
 	return CassandraConfig{}
 }
 
+func (c *TestErrorCassandra) Session() *gocql.Session {
+	return nil
+}
+
 func (c *TestErrorCassandra) ExecuteQuery(queryString string, queryParams ...interface{}) error {
 	return fmt.Errorf("Error during ExecuteQuery")
 }


### PR DESCRIPTION
## Purpose
Sometimes it's useful to retrieve the session object and interact with gocql directly. Mostly this is useful to get metrics out of the session object. 