### PR TITLE
Add context to ExecuteQuery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY: integration-test
+integration-test:
+	go test ./... -race -timeout 1m --count=1

--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -1,6 +1,7 @@
 package sandra
 
 import (
+	"context"
 	"testing"
 
 	"github.com/gocql/gocql"
@@ -58,6 +59,16 @@ func (s *CassandraSuite) TestExecuteQuerySuccess(c *C) {
 
 func (s *CassandraSuite) TestExecuteQueryError(c *C) {
 	err := s.cassandra.ExecuteQuery("drop table unknown")
+	c.Assert(err, NotNil)
+}
+
+func (s *CassandraSuite) TestExecuteQueryCtxSuccess(c *C) {
+	err := s.cassandra.ExecuteQueryCtx(context.Background(), "insert into test (field) values (1)")
+	c.Assert(err, IsNil)
+}
+
+func (s *CassandraSuite) TestExecuteQueryCtxError(c *C) {
+	err := s.cassandra.ExecuteQueryCtx(context.Background(), "drop table unknown")
 	c.Assert(err, NotNil)
 }
 

--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -72,6 +72,15 @@ func (s *CassandraSuite) TestExecuteQueryCtxError(c *C) {
 	c.Assert(err, NotNil)
 }
 
+func (s *CassandraSuite) TestExecuteQueryCtxCanceled(c *C) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := s.cassandra.ExecuteQueryCtx(ctx, "insert into test (field) values (1)")
+	c.Log(err)
+	c.Assert(err, NotNil)
+}
+
 func (s *CassandraSuite) TestExecuteBatchSuccess(c *C) {
 	queries := []string{
 		"insert into test (field) values (?)",

--- a/testutils_test.go
+++ b/testutils_test.go
@@ -1,10 +1,10 @@
 package sandra
 
 import (
+	"context"
 	"fmt"
-	"time"
-
 	"sync"
+	"time"
 
 	"github.com/gocql/gocql"
 	"github.com/pkg/errors"
@@ -22,6 +22,10 @@ func (c *TestErrorCassandra) Config() CassandraConfig {
 
 func (c *TestErrorCassandra) Session() *gocql.Session {
 	return nil
+}
+
+func (c *TestErrorCassandra) ExecuteQueryCtx(_ context.Context, queryString string, queryParams ...interface{}) error {
+	return fmt.Errorf("error during ExecuteQueryCtx")
 }
 
 func (c *TestErrorCassandra) ExecuteQuery(queryString string, queryParams ...interface{}) error {


### PR DESCRIPTION
Context controls the entire lifetime of executing a query, queries will be canceled and returned once the context is canceled.