### PR TITLE
Added ScanQuery with Context

### DIFF
--- a/testutils.go
+++ b/testutils.go
@@ -37,6 +37,10 @@ func (c *TestErrorCassandra) ExecuteUnloggedBatch(queries []string, params [][]i
 	return fmt.Errorf("Error during ExecuteUnloggedBatch")
 }
 
+func (c *TestErrorCassandra) ScanQueryCtx(_ context.Context, queryString string, queryParams []interface{}, outParams ...interface{}) error {
+	return fmt.Errorf("Error during ScanQueryCtx")
+}
+
 func (c *TestErrorCassandra) ScanQuery(queryString string, queryParams []interface{}, outParams ...interface{}) error {
 	return fmt.Errorf("Error during ScanQuery")
 }


### PR DESCRIPTION
Added a new method that allows a context to be passed when executing a scan query.